### PR TITLE
Custom Annotation for Address Format Validation #7

### DIFF
--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/model/Owner.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/model/Owner.java
@@ -21,6 +21,7 @@ import jakarta.validation.constraints.NotBlank;
 import org.springframework.beans.support.MutableSortDefinition;
 import org.springframework.beans.support.PropertyComparator;
 import org.springframework.core.style.ToStringCreator;
+import org.springframework.samples.petclinic.customers.validation.ValidAddress;
 
 import java.util.*;
 
@@ -52,6 +53,7 @@ public class Owner {
 
     @Column(name = "address")
     @NotBlank
+    @ValidAddress
     private String address;
 
     @Column(name = "city")

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/validation/ValidAddress.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/validation/ValidAddress.java
@@ -1,0 +1,27 @@
+package org.springframework.samples.petclinic.customers.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Custom constraint annotation to validate address format.
+ * Ensures that an address contains at least a street number followed by a street name.
+ */
+@Documented
+@Constraint(validatedBy = ValidAddressValidator.class)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidAddress {
+
+    String message() default "{org.springframework.samples.petclinic.customers.validation.ValidAddress.message}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/validation/ValidAddressValidator.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/validation/ValidAddressValidator.java
@@ -1,0 +1,33 @@
+package org.springframework.samples.petclinic.customers.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.regex.Pattern;
+
+/**
+ * Validator implementation for the {@link ValidAddress} constraint.
+ * Validates that an address contains at least a street number followed by a street name.
+ */
+public class ValidAddressValidator implements ConstraintValidator<ValidAddress, String> {
+
+    // Pattern to match a street number followed by a street name
+    // Matches: digits followed by whitespace followed by at least one word character
+    private static final Pattern ADDRESS_PATTERN = Pattern.compile("\\d+\\s+\\w+.*");
+
+    @Override
+    public void initialize(ValidAddress constraintAnnotation) {
+        // No initialization needed
+    }
+
+    @Override
+    public boolean isValid(String address, ConstraintValidatorContext context) {
+        // Null values are handled by @NotNull annotation if needed
+        if (address == null || address.trim().isEmpty()) {
+            return true;
+        }
+
+        // Check if the address matches the required pattern
+        return ADDRESS_PATTERN.matcher(address).matches();
+    }
+}

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/OwnerRequest.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/OwnerRequest.java
@@ -2,10 +2,11 @@ package org.springframework.samples.petclinic.customers.web;
 
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.samples.petclinic.customers.validation.ValidAddress;
 
 public record OwnerRequest(@NotBlank String firstName,
                            @NotBlank String lastName,
-                           @NotBlank String address,
+                           @NotBlank @ValidAddress String address,
                            @NotBlank String city,
                            @NotBlank
                            @Digits(fraction = 0, integer = 12)

--- a/spring-petclinic-customers-service/src/main/resources/ValidationMessages.properties
+++ b/spring-petclinic-customers-service/src/main/resources/ValidationMessages.properties
@@ -1,0 +1,2 @@
+# Validation messages for the customers service
+org.springframework.samples.petclinic.customers.validation.ValidAddress.message=Address must contain a street number followed by a street name

--- a/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/validation/ValidAddressValidatorTest.java
+++ b/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/validation/ValidAddressValidatorTest.java
@@ -1,0 +1,54 @@
+package org.springframework.samples.petclinic.customers.validation;
+
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test class for {@link ValidAddressValidator}
+ */
+@ExtendWith(MockitoExtension.class)
+class ValidAddressValidatorTest {
+
+    private ValidAddressValidator validator;
+
+    @Mock
+    private ConstraintValidatorContext context;
+
+    @BeforeEach
+    void setUp() {
+        validator = new ValidAddressValidator();
+    }
+
+    @Test
+    void shouldValidateCorrectAddress() {
+        // Valid addresses with street number followed by street name
+        assertTrue(validator.isValid("123 Main Street", context));
+        assertTrue(validator.isValid("45 Park Avenue", context));
+        assertTrue(validator.isValid("67 Oak Street, Apt 2B", context));
+        assertTrue(validator.isValid("890 Pine Road, Suite 100", context));
+    }
+
+    @Test
+    void shouldNotValidateIncorrectAddress() {
+        // Invalid addresses without street number or street name
+        assertFalse(validator.isValid("Main Street", context));
+        assertFalse(validator.isValid("123", context));
+        assertFalse(validator.isValid("123,", context));
+        assertFalse(validator.isValid("No street number here", context));
+    }
+
+    @Test
+    void shouldHandleNullAndEmptyValues() {
+        // Null and empty values should be considered valid (handled by @NotBlank)
+        assertTrue(validator.isValid(null, context));
+        assertTrue(validator.isValid("", context));
+        assertTrue(validator.isValid("   ", context));
+    }
+}


### PR DESCRIPTION
This commit adds address format validation functionality to the PetClinic application. The key changes include creating a custom annotation and its validator to ensure addresses contain a street number followed by a street name using regex pattern matching. The validation has been applied to both the Owner entity and OwnerRequest classes, with appropriate validation messages provided through properties file. @ValidAddress