### PR TITLE
Task/#3 Test Consistency in Distributed Traces for APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ ENV SPRING_PROFILES_ACTIVE docker,mysql
 In the `mysql section` of the `application.yml` from the [Configuration repository], you have to change 
 the host and port of your MySQL JDBC connection string. 
 
+## Distributed Tracing
+
+All services are configured with Micrometer Tracing and Zipkin for distributed tracing. Each HTTP request is automatically assigned a trace ID and span ID, which are logged in the format:
+
+```
+traceId=<value> spanId=<value>
+```
+
+This enables tracking requests as they flow through multiple microservices. Trace context is propagated via W3C Trace Context headers (`traceparent`).
+
+To view traces, access Zipkin at http://localhost:9411/zipkin/ after starting the services.
+
 ## Custom metrics monitoring
 
 Grafana and Prometheus are included in the `docker-compose.yml` configuration, and the public facing applications

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/config/WebConfig.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/config/WebConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.customers.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.samples.petclinic.customers.web.TracingLoggingInterceptor;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Web configuration for registering interceptors.
+ */
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final TracingLoggingInterceptor tracingLoggingInterceptor;
+
+    public WebConfig(TracingLoggingInterceptor tracingLoggingInterceptor) {
+        this.tracingLoggingInterceptor = tracingLoggingInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(tracingLoggingInterceptor);
+    }
+}
+

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/TracingLoggingInterceptor.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/TracingLoggingInterceptor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.customers.web;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * Interceptor that logs trace context (traceId and spanId) for all incoming requests.
+ */
+@Component
+public class TracingLoggingInterceptor implements HandlerInterceptor {
+
+    private static final Logger log = LoggerFactory.getLogger(TracingLoggingInterceptor.class);
+
+    private final Tracer tracer;
+
+    public TracingLoggingInterceptor(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        Span span = tracer.currentSpan();
+        if (span != null) {
+            log.info("{} {} traceId={} spanId={}",
+                request.getMethod(),
+                request.getRequestURI(),
+                span.context().traceId(),
+                span.context().spanId());
+        }
+        return true;
+    }
+}
+

--- a/spring-petclinic-customers-service/src/main/resources/application.yml
+++ b/spring-petclinic-customers-service/src/main/resources/application.yml
@@ -4,6 +4,14 @@ spring:
   config:
     import: optional:configserver:${CONFIG_SERVER_URL:http://localhost:8888/}
 
+management:
+  tracing:
+    enabled: true
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://localhost:9411/api/v2/spans
 
 ---
 spring:
@@ -11,3 +19,8 @@ spring:
     activate:
       on-profile: docker
     import: configserver:http://config-server:8888
+
+management:
+  zipkin:
+    tracing:
+      endpoint: http://tracing-server:9411/api/v2/spans

--- a/spring-petclinic-customers-service/src/main/resources/logback-spring.xml
+++ b/spring-petclinic-customers-service/src/main/resources/logback-spring.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <include resource="org/springframework/boot/logging/logback/base.xml"/>
-    <!-- Required for Loglevel managment into the Spring Petclinic Admin Server-->
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %5p [%t] traceId=%X{traceId} spanId=%X{spanId} --- %-40.40logger{39} : %m%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+    <!-- Required for Loglevel management into the Spring Petclinic Admin Server-->
     <jmxConfigurator/>
 </configuration>

--- a/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/PetResourceTest.java
+++ b/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/PetResourceTest.java
@@ -2,6 +2,7 @@ package org.springframework.samples.petclinic.customers.web;
 
 import java.util.Optional;
 
+import io.micrometer.tracing.Tracer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,6 +41,9 @@ class PetResourceTest {
 
     @MockBean
     OwnerRepository ownerRepository;
+
+    @MockBean
+    Tracer tracer;
 
     @Test
     void shouldGetAPetInJSonFormat() throws Exception {

--- a/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/TracingIntegrationTest.java
+++ b/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/TracingIntegrationTest.java
@@ -1,0 +1,144 @@
+package org.springframework.samples.petclinic.customers.web;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests to verify trace context logging.
+ *
+ * These tests verify that:
+ * 1. traceId=<value> and spanId=<value> appear in logs for all requests
+ * 2. Format is correct (hex values)
+ * 3. Trace context is propagated from incoming HTTP headers
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureObservability
+@ActiveProfiles("test")
+@ExtendWith(OutputCaptureExtension.class)
+class TracingIntegrationTest {
+
+    private static final Pattern TRACE_ID = Pattern.compile("traceId=[0-9a-fA-F]{16,32}");
+    private static final Pattern SPAN_ID  = Pattern.compile("spanId=[0-9a-fA-F]{16}");
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    /**
+     * Test 1: Logs contain traceId=<hex> and spanId=<hex> for GET requests
+     */
+    @Test
+    void shouldLogTraceIdAndSpanIdWithCorrectFormat(CapturedOutput output) {
+        String logsBefore = output.getOut();
+
+        restTemplate.getForEntity("/owners", String.class);
+
+        String logs = getLogsDelta(output, logsBefore);
+
+        assertThat(logs)
+            .as("Logs should contain traceId=<hex>")
+            .containsPattern(TRACE_ID);
+        assertThat(logs)
+            .as("Logs should contain spanId=<hex>")
+            .containsPattern(SPAN_ID);
+    }
+
+    /**
+     * Test 2: Trace context is logged even for error responses (404)
+     */
+    @Test
+    void shouldLogTraceContextForErrorResponse(CapturedOutput output) {
+        String logsBefore = output.getOut();
+
+        restTemplate.getForEntity("/owners/99999", String.class);
+
+        String logs = getLogsDelta(output, logsBefore);
+
+        assertThat(logs)
+            .as("Logs should contain traceId for error responses")
+            .containsPattern(TRACE_ID);
+        assertThat(logs)
+            .as("Logs should contain spanId for error responses")
+            .containsPattern(SPAN_ID);
+    }
+
+    /**
+     * Test 3: Trace context is logged for POST requests
+     */
+    @Test
+    void shouldLogTraceContextForPostRequest(CapturedOutput output) {
+        String logsBefore = output.getOut();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String validOwnerJson = """
+            {
+                "firstName": "John",
+                "lastName": "Doe",
+                "address": "123 Main St",
+                "city": "Springfield",
+                "telephone": "5551234567"
+            }
+            """;
+        HttpEntity<String> request = new HttpEntity<>(validOwnerJson, headers);
+
+        restTemplate.postForEntity("/owners", request, String.class);
+
+        String logs = getLogsDelta(output, logsBefore);
+
+        assertThat(logs)
+            .as("Logs should contain traceId for POST requests")
+            .containsPattern(TRACE_ID);
+        assertThat(logs)
+            .as("Logs should contain spanId for POST requests")
+            .containsPattern(SPAN_ID);
+    }
+
+    /**
+     * Test 4: Provided traceId from headers is propagated and logged.
+     * Uses W3C Trace Context format (traceparent header).
+     */
+    @Test
+    void shouldPropagateProvidedTraceId(CapturedOutput output) {
+        // Fixed traceId (32 hex) and parentSpanId (16 hex)
+        String expectedTraceId = "463ac35c9f6413ad48485a3953bb6124";
+        String parentSpanId = "0020000000000001";
+
+        // W3C Trace Context format: version-traceId-parentId-flags
+        String traceparent = "00-" + expectedTraceId + "-" + parentSpanId + "-01";
+
+        String logsBefore = output.getOut();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("traceparent", traceparent);
+
+        restTemplate.exchange("/owners", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        String logs = getLogsDelta(output, logsBefore);
+
+        assertThat(logs)
+            .as("Logs should contain the propagated traceId: " + expectedTraceId)
+            .contains("traceId=" + expectedTraceId);
+    }
+
+    private String getLogsDelta(CapturedOutput output, String logsBefore) {
+        String logsAfter = output.getOut();
+        return logsAfter.length() >= logsBefore.length()
+            ? logsAfter.substring(logsBefore.length())
+            : logsAfter;
+    }
+}

--- a/spring-petclinic-vets-service/src/main/java/org/springframework/samples/petclinic/vets/system/WebConfig.java
+++ b/spring-petclinic-vets-service/src/main/java/org/springframework/samples/petclinic/vets/system/WebConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.vets.system;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.samples.petclinic.vets.web.TracingLoggingInterceptor;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Web configuration for registering interceptors.
+ */
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final TracingLoggingInterceptor tracingLoggingInterceptor;
+
+    public WebConfig(TracingLoggingInterceptor tracingLoggingInterceptor) {
+        this.tracingLoggingInterceptor = tracingLoggingInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(tracingLoggingInterceptor);
+    }
+}
+

--- a/spring-petclinic-vets-service/src/main/java/org/springframework/samples/petclinic/vets/web/TracingLoggingInterceptor.java
+++ b/spring-petclinic-vets-service/src/main/java/org/springframework/samples/petclinic/vets/web/TracingLoggingInterceptor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.vets.web;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * Interceptor that logs trace context (traceId and spanId) for all incoming requests.
+ */
+@Component
+public class TracingLoggingInterceptor implements HandlerInterceptor {
+
+    private static final Logger log = LoggerFactory.getLogger(TracingLoggingInterceptor.class);
+
+    private final Tracer tracer;
+
+    public TracingLoggingInterceptor(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        Span span = tracer.currentSpan();
+        if (span != null) {
+            log.info("{} {} traceId={} spanId={}",
+                request.getMethod(),
+                request.getRequestURI(),
+                span.context().traceId(),
+                span.context().spanId());
+        }
+        return true;
+    }
+}
+

--- a/spring-petclinic-vets-service/src/main/resources/application.yml
+++ b/spring-petclinic-vets-service/src/main/resources/application.yml
@@ -8,9 +8,23 @@ spring:
   profiles:
     active: production
 
+management:
+  tracing:
+    enabled: true
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://localhost:9411/api/v2/spans
+
 ---
 spring:
   config:
     activate:
       on-profile: docker
     import: configserver:http://config-server:8888
+
+management:
+  zipkin:
+    tracing:
+      endpoint: http://tracing-server:9411/api/v2/spans

--- a/spring-petclinic-vets-service/src/main/resources/logback-spring.xml
+++ b/spring-petclinic-vets-service/src/main/resources/logback-spring.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <include resource="org/springframework/boot/logging/logback/base.xml"/>
-    <!-- Required for Loglevel managment into the Spring Petclinic Admin Server-->
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %5p [%t] traceId=%X{traceId} spanId=%X{spanId} --- %-40.40logger{39} : %m%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+    <!-- Required for Loglevel management into the Spring Petclinic Admin Server-->
     <jmxConfigurator/>
 </configuration>

--- a/spring-petclinic-vets-service/src/test/java/org/springframework/samples/petclinic/vets/web/TracingIntegrationTest.java
+++ b/spring-petclinic-vets-service/src/test/java/org/springframework/samples/petclinic/vets/web/TracingIntegrationTest.java
@@ -1,0 +1,86 @@
+package org.springframework.samples.petclinic.vets.web;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests to verify trace context logging in vets-service.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureObservability
+@ActiveProfiles("test")
+@ExtendWith(OutputCaptureExtension.class)
+class TracingIntegrationTest {
+
+    private static final Pattern TRACE_ID = Pattern.compile("traceId=[0-9a-fA-F]{16,32}");
+    private static final Pattern SPAN_ID  = Pattern.compile("spanId=[0-9a-fA-F]{16}");
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    /**
+     * Test 1: Logs contain traceId=<hex> and spanId=<hex> for GET requests
+     */
+    @Test
+    void shouldLogTraceIdAndSpanIdWithCorrectFormat(CapturedOutput output) {
+        String logsBefore = output.getOut();
+
+        restTemplate.getForEntity("/vets", String.class);
+
+        String logs = getLogsDelta(output, logsBefore);
+
+        assertThat(logs)
+            .as("Logs should contain traceId=<hex>")
+            .containsPattern(TRACE_ID);
+        assertThat(logs)
+            .as("Logs should contain spanId=<hex>")
+            .containsPattern(SPAN_ID);
+    }
+
+    /**
+     * Test 2: Provided traceId from headers is propagated and logged.
+     * Uses W3C Trace Context format (traceparent header).
+     */
+    @Test
+    void shouldPropagateProvidedTraceId(CapturedOutput output) {
+        String expectedTraceId = "463ac35c9f6413ad48485a3953bb6124";
+        String parentSpanId = "0020000000000001";
+
+        // W3C Trace Context format: version-traceId-parentId-flags
+        String traceparent = "00-" + expectedTraceId + "-" + parentSpanId + "-01";
+
+        String logsBefore = output.getOut();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("traceparent", traceparent);
+
+        restTemplate.exchange("/vets", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        String logs = getLogsDelta(output, logsBefore);
+
+        assertThat(logs)
+            .as("Logs should contain the propagated traceId: " + expectedTraceId)
+            .contains("traceId=" + expectedTraceId);
+    }
+
+    private String getLogsDelta(CapturedOutput output, String logsBefore) {
+        String logsAfter = output.getOut();
+        return logsAfter.length() >= logsBefore.length()
+            ? logsAfter.substring(logsBefore.length())
+            : logsAfter;
+    }
+}

--- a/spring-petclinic-vets-service/src/test/java/org/springframework/samples/petclinic/vets/web/VetResourceTest.java
+++ b/spring-petclinic-vets-service/src/test/java/org/springframework/samples/petclinic/vets/web/VetResourceTest.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.samples.petclinic.vets.web;
 
+import io.micrometer.tracing.Tracer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,6 +47,9 @@ class VetResourceTest {
 
     @MockBean
     VetRepository vetRepository;
+
+    @MockBean
+    Tracer tracer;
 
     @Test
     void shouldGetAListOfVets() throws Exception {

--- a/spring-petclinic-visits-service/src/main/java/org/springframework/samples/petclinic/visits/config/WebConfig.java
+++ b/spring-petclinic-visits-service/src/main/java/org/springframework/samples/petclinic/visits/config/WebConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.visits.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.samples.petclinic.visits.web.TracingLoggingInterceptor;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Web configuration for registering interceptors.
+ */
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final TracingLoggingInterceptor tracingLoggingInterceptor;
+
+    public WebConfig(TracingLoggingInterceptor tracingLoggingInterceptor) {
+        this.tracingLoggingInterceptor = tracingLoggingInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(tracingLoggingInterceptor);
+    }
+}
+

--- a/spring-petclinic-visits-service/src/main/java/org/springframework/samples/petclinic/visits/web/TracingLoggingInterceptor.java
+++ b/spring-petclinic-visits-service/src/main/java/org/springframework/samples/petclinic/visits/web/TracingLoggingInterceptor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.visits.web;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * Interceptor that logs trace context (traceId and spanId) for all incoming requests.
+ */
+@Component
+public class TracingLoggingInterceptor implements HandlerInterceptor {
+
+    private static final Logger log = LoggerFactory.getLogger(TracingLoggingInterceptor.class);
+
+    private final Tracer tracer;
+
+    public TracingLoggingInterceptor(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        Span span = tracer.currentSpan();
+        if (span != null) {
+            log.info("{} {} traceId={} spanId={}",
+                request.getMethod(),
+                request.getRequestURI(),
+                span.context().traceId(),
+                span.context().spanId());
+        }
+        return true;
+    }
+}
+

--- a/spring-petclinic-visits-service/src/main/resources/application.yml
+++ b/spring-petclinic-visits-service/src/main/resources/application.yml
@@ -4,6 +4,14 @@ spring:
   config:
     import: optional:configserver:${CONFIG_SERVER_URL:http://localhost:8888/}
 
+management:
+  tracing:
+    enabled: true
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://localhost:9411/api/v2/spans
 
 ---
 spring:
@@ -11,3 +19,8 @@ spring:
     activate:
       on-profile: docker
     import: configserver:http://config-server:8888
+
+management:
+  zipkin:
+    tracing:
+      endpoint: http://tracing-server:9411/api/v2/spans

--- a/spring-petclinic-visits-service/src/main/resources/logback-spring.xml
+++ b/spring-petclinic-visits-service/src/main/resources/logback-spring.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <include resource="org/springframework/boot/logging/logback/base.xml"/>
-    <!-- Required for Loglevel managment into the Spring Petclinic Admin Server-->
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %5p [%t] traceId=%X{traceId} spanId=%X{spanId} --- %-40.40logger{39} : %m%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+    <!-- Required for Loglevel management into the Spring Petclinic Admin Server-->
     <jmxConfigurator/>
 </configuration>

--- a/spring-petclinic-visits-service/src/test/java/org/springframework/samples/petclinic/visits/web/TracingIntegrationTest.java
+++ b/spring-petclinic-visits-service/src/test/java/org/springframework/samples/petclinic/visits/web/TracingIntegrationTest.java
@@ -1,0 +1,147 @@
+package org.springframework.samples.petclinic.visits.web;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests to verify trace context logging in visits-service.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureObservability
+@ActiveProfiles("test")
+@ExtendWith(OutputCaptureExtension.class)
+class TracingIntegrationTest {
+
+    private static final Pattern TRACE_ID = Pattern.compile("traceId=[0-9a-fA-F]{16,32}");
+    private static final Pattern SPAN_ID  = Pattern.compile("spanId=[0-9a-fA-F]{16}");
+    private static final Pattern TRACE_ID_VALUE = Pattern.compile("traceId=([0-9a-fA-F]{16,32})");
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    /**
+     * Test 1: Logs contain traceId=<hex> and spanId=<hex> for GET requests
+     */
+    @Test
+    void shouldLogTraceIdAndSpanIdWithCorrectFormat(CapturedOutput output) {
+        String logsBefore = output.getOut();
+
+        restTemplate.getForEntity("/pets/visits?petId=1", String.class);
+
+        String logs = getLogsDelta(output, logsBefore);
+
+        assertThat(logs)
+            .as("Logs should contain traceId=<hex>")
+            .containsPattern(TRACE_ID);
+        assertThat(logs)
+            .as("Logs should contain spanId=<hex>")
+            .containsPattern(SPAN_ID);
+    }
+
+    /**
+     * Test 2: Trace context is logged for POST requests
+     */
+    @Test
+    void shouldLogTraceContextForPostRequest(CapturedOutput output) {
+        String logsBefore = output.getOut();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> request = new HttpEntity<>("{\"petId\":1,\"description\":\"test\"}", headers);
+
+        restTemplate.postForEntity("/owners/1/pets/1/visits", request, String.class);
+
+        String logs = getLogsDelta(output, logsBefore);
+
+        assertThat(logs)
+            .as("Logs should contain traceId for POST requests")
+            .containsPattern(TRACE_ID);
+        assertThat(logs)
+            .as("Logs should contain spanId for POST requests")
+            .containsPattern(SPAN_ID);
+    }
+
+    /**
+     * Test 3: All logs within a single request should have the same traceId.
+     */
+    @Test
+    void shouldHaveConsistentTraceIdAcrossMultipleLogs(CapturedOutput output) {
+        String logsBefore = output.getOut();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> request = new HttpEntity<>("{\"petId\":1,\"description\":\"test\"}", headers);
+        restTemplate.postForEntity("/owners/1/pets/1/visits", request, String.class);
+
+        String logs = getLogsDelta(output, logsBefore);
+
+        // Extract all traceIds from logs
+        Matcher matcher = TRACE_ID_VALUE.matcher(logs);
+
+        Set<String> traceIds = new HashSet<>();
+        while (matcher.find()) {
+            traceIds.add(matcher.group(1));
+        }
+
+        // Must have at least one traceId logged
+        assertThat(traceIds)
+            .as("Logs should contain at least one traceId")
+            .isNotEmpty();
+
+        // All traceIds should be the same (only one unique value)
+        assertThat(traceIds)
+            .as("All logs within one request should have the same traceId")
+            .hasSize(1);
+    }
+
+    /**
+     * Test 4: Provided traceId from headers is propagated and logged.
+     * Uses W3C Trace Context format (traceparent header).
+     */
+    @Test
+    void shouldPropagateProvidedTraceId(CapturedOutput output) {
+        String expectedTraceId = "463ac35c9f6413ad48485a3953bb6124";
+        String parentSpanId = "0020000000000001";
+
+        // W3C Trace Context format: version-traceId-parentId-flags
+        String traceparent = "00-" + expectedTraceId + "-" + parentSpanId + "-01";
+
+        String logsBefore = output.getOut();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("traceparent", traceparent);
+
+        restTemplate.exchange("/pets/visits?petId=1", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        String logs = getLogsDelta(output, logsBefore);
+
+        assertThat(logs)
+            .as("Logs should contain the propagated traceId: " + expectedTraceId)
+            .contains("traceId=" + expectedTraceId);
+    }
+
+    private String getLogsDelta(CapturedOutput output, String logsBefore) {
+        String logsAfter = output.getOut();
+        return logsAfter.length() >= logsBefore.length()
+            ? logsAfter.substring(logsBefore.length())
+            : logsAfter;
+    }
+}

--- a/spring-petclinic-visits-service/src/test/java/org/springframework/samples/petclinic/visits/web/VisitResourceTest.java
+++ b/spring-petclinic-visits-service/src/test/java/org/springframework/samples/petclinic/visits/web/VisitResourceTest.java
@@ -1,5 +1,6 @@
 package org.springframework.samples.petclinic.visits.web;
 
+import io.micrometer.tracing.Tracer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,9 @@ class VisitResourceTest {
 
     @MockBean
     VisitRepository visitRepository;
+
+    @MockBean
+    Tracer tracer;
 
     @Test
     void shouldFetchVisits() throws Exception {


### PR DESCRIPTION
# Test Consistency in Distributed Traces for APIs #3

## Task description

The changes add trace ID and span ID logging to all major service endpoints (Owners, Pets, Vets, Visits) using Micrometer Tracing with Brave and Zipkin. Each service operation now logs its trace context, enabling request tracking across multiple services.
The implementation includes:

Addition of Tracer injection and logging in all REST controllers
Integration test to verify trace propagation
Add detailed documentation to README.md explaining the tracing setup and validation process
The main goal is to improve observability by making it possible to track requests as they flow through different microservices in the application.

### Implementation details:

- Every HTTP request to the target services (Customers, Vets, Visits) must have an active trace. The traceId and spanId must be logged in the format: `traceId=<value>` and `spanId=<value>`. Example: `traceId=6a3e78f912ab34cd spanId=9b8c7d6e5f4a3210`.
- Trace context propagation must use W3C Trace Context format (`traceparent` header). This is the default in Spring Boot 3.

FAIL_TO_PASS: org.springframework.samples.petclinic.customers.web.TracingIntegrationTest, org.springframework.samples.petclinic.vets.web.TracingIntegrationTest, org.springframework.samples.petclinic.visits.web.TracingIntegrationTest