### PR TITLE
Simulate an External API with WireMock for Integration Tests

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,10 @@
   "jvm_version": "17",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "spring-petclinic-api-gateway:org.springframework.samples.petclinic.api.application.VisitsServiceClientWireMockTest",
+      "spring-petclinic-api-gateway:org.springframework.samples.petclinic.api.application.VisitsServiceSpringBootWireMockTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/docs/wiremock-testing.md
+++ b/docs/wiremock-testing.md
@@ -1,0 +1,188 @@
+# Using WireMock for Integration Testing
+
+This document explains how to use WireMock to mock external API dependencies in the Spring PetClinic microservices project.
+
+## Overview
+
+WireMock is a library for stubbing and mocking web services. It can be used to simulate external API dependencies in integration tests, allowing you to test your application without relying on actual external services.
+
+In this project, we've implemented WireMock to mock the Visits service in the API Gateway's integration tests.
+
+## Dependencies
+
+To use WireMock in your tests, you need to add the following dependency to your `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-starter-contract-stub-runner</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+This dependency includes WireMock and the Spring Cloud Contract Stub Runner, which provides integration with Spring Boot's test framework.
+
+## Standalone WireMock Tests
+
+For standalone tests that don't require the Spring Boot context, you can use the `WireMockExtension` JUnit 5 extension. Here's an example:
+
+```java
+@RegisterExtension
+static WireMockExtension wireMockServer = WireMockExtension.newInstance()
+        .options(wireMockConfig().dynamicPort())
+        .build();
+
+@BeforeEach
+void setUp() {
+    // Configure your client to use the WireMock server
+    client.setBaseUrl(wireMockServer.baseUrl());
+}
+
+@Test
+void testWithWireMock() {
+    // Setup the WireMock stub
+    wireMockServer.stubFor(get(urlPathEqualTo("/api/resource"))
+            .withQueryParam("param", equalTo("value"))
+            .willReturn(aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"key\":\"value\"}")));
+
+    // Call your client
+    Response response = client.getResource("value");
+
+    // Verify the response
+    assertEquals("value", response.getKey());
+
+    // Verify that the expected request was made to the mock server
+    wireMockServer.verify(getRequestedFor(urlPathEqualTo("/api/resource"))
+            .withQueryParam("param", equalTo("value")));
+}
+```
+
+See `VisitsServiceClientWireMockTest.java` for a complete example.
+
+## Spring Boot Integration Tests with WireMock
+
+For integration tests that require the Spring Boot context, you can use the `@AutoConfigureWireMock` annotation. Here's an example:
+
+```java
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@AutoConfigureWireMock(port = 0) // Use a random port
+@TestPropertySource(properties = {
+    "spring.cloud.discovery.enabled=false",
+    "spring.cloud.config.enabled=false",
+    "spring.cloud.loadbalancer.enabled=false"
+})
+class ServiceIntegrationTest {
+
+    @Autowired
+    private YourClient client;
+    
+    @Value("${wiremock.server.port}")
+    private int wireMockPort;
+
+    @BeforeEach
+    void setUp() {
+        // Reset WireMock to ensure clean state for each test
+        WireMock.reset();
+        
+        // Configure your client to use the WireMock server
+        client.setBaseUrl("http://localhost:" + wireMockPort);
+    }
+
+    @Test
+    void testWithWireMock() {
+        // Setup the WireMock stub
+        stubFor(get(urlPathEqualTo("/api/resource"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"key\":\"value\"}")));
+
+        // Call your client
+        Response response = client.getResource();
+
+        // Verify the response
+        assertEquals("value", response.getKey());
+
+        // Verify that the expected request was made to the mock server
+        verify(getRequestedFor(urlPathEqualTo("/api/resource")));
+    }
+}
+```
+
+See `VisitsServiceSpringBootWireMockTest.java` for a complete example.
+
+## Test Configuration
+
+To configure your application for testing with WireMock, you can create an `application-test.yml` file in your test resources directory:
+
+```yaml
+spring:
+  cloud:
+    config:
+      enabled: false
+    discovery:
+      enabled: false
+    loadbalancer:
+      enabled: false
+  main:
+    allow-bean-definition-overriding: true
+
+# Disable Eureka client
+eureka:
+  client:
+    enabled: false
+    register-with-eureka: false
+    fetch-registry: false
+
+# Logging configuration for tests
+logging:
+  level:
+    org.springframework.web: INFO
+    org.springframework.samples.petclinic: DEBUG
+    # WireMock logging
+    com.github.tomakehurst.wiremock: DEBUG
+```
+
+This configuration disables Spring Cloud Config, Discovery, and Load Balancer, which can interfere with WireMock testing.
+
+## Best Practices
+
+1. **Use URL Path Matching**: When setting up stubs, use `urlPathEqualTo` instead of `urlEqualTo` to match only the path part of the URL. This is more flexible and handles URL encoding of query parameters.
+
+2. **Separate Query Parameter Matching**: Use `.withQueryParam("name", equalTo("value"))` to match query parameters separately from the path.
+
+3. **Reset WireMock Between Tests**: Call `WireMock.reset()` in your `@BeforeEach` method to ensure a clean state for each test.
+
+4. **Verify Requests**: Use `verify` to ensure that the expected requests were made to the mock server.
+
+5. **Handle URL Encoding**: Be aware that query parameters are URL-encoded in requests. For example, a comma (`,`) is encoded as `%2C`.
+
+## Examples
+
+For complete examples of using WireMock in this project, see:
+
+- `VisitsServiceClientWireMockTest.java`: A standalone test that uses WireMock to mock the Visits service.
+- `VisitsServiceSpringBootWireMockTest.java`: A Spring Boot integration test that uses WireMock with the Spring Boot test framework.
+- `application-test.yml`: Configuration for testing with WireMock.
+
+## Troubleshooting
+
+If you encounter issues with WireMock in your tests, check the following:
+
+1. **URL Matching**: Ensure that your URL matchers (e.g., `urlPathEqualTo`, `urlEqualTo`) match the actual requests being made.
+
+2. **Query Parameters**: Be aware that query parameters are URL-encoded in requests. Use separate query parameter matchers for more flexibility.
+
+3. **Service Resolution**: If you're using Spring Cloud's service discovery, ensure it's properly disabled in your test configuration.
+
+4. **Load Balancing**: If you're using Spring Cloud's load balancer, ensure it's properly disabled in your test configuration.
+
+5. **Logging**: Enable debug logging for WireMock to see detailed information about requests and responses.
+
+## Conclusion
+
+WireMock is a powerful tool for mocking external API dependencies in integration tests. By using WireMock, you can test your application without relying on actual external services, making your tests more reliable and faster.
+
+For more information about WireMock, see the [official documentation](http://wiremock.org/docs/).

--- a/spring-petclinic-api-gateway/pom.xml
+++ b/spring-petclinic-api-gateway/pom.xml
@@ -153,6 +153,11 @@
             <version>${squareup-okhttp3.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-contract-stub-runner</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/spring-petclinic-api-gateway/src/test/java/org/springframework/samples/petclinic/api/application/VisitsServiceClientWireMockTest.java
+++ b/spring-petclinic-api-gateway/src/test/java/org/springframework/samples/petclinic/api/application/VisitsServiceClientWireMockTest.java
@@ -1,0 +1,94 @@
+package org.springframework.samples.petclinic.api.application;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.samples.petclinic.api.dto.Visits;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.Collections;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Integration test for VisitsServiceClient using WireMock to simulate an external API.
+ * This demonstrates how to use WireMock to mock external API dependencies in Spring Boot applications.
+ */
+class VisitsServiceClientWireMockTest {
+
+    private static final Integer PET_ID = 1;
+
+    @RegisterExtension
+    static WireMockExtension wireMockServer = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    private VisitsServiceClient visitsServiceClient;
+
+    @BeforeEach
+    void setUp() {
+        visitsServiceClient = new VisitsServiceClient(WebClient.builder());
+        visitsServiceClient.setHostname(wireMockServer.baseUrl() + "/");
+    }
+
+    @Test
+    void getVisitsForPets_withAvailableVisitsService() {
+        // Setup the WireMock stub for the visits service
+        wireMockServer.stubFor(get(urlEqualTo("/pets/visits?petId=" + PET_ID))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"items\":[{\"id\":5,\"date\":\"2018-11-15\",\"description\":\"test visit\",\"petId\":1}]}")));
+
+        // Call the service client
+        Mono<Visits> visits = visitsServiceClient.getVisitsForPets(Collections.singletonList(PET_ID));
+
+        // Verify the response
+        assertVisitDescriptionEquals(visits.block(), PET_ID, "test visit");
+
+        // Verify that the expected request was made to the mock server
+        wireMockServer.verify(getRequestedFor(urlEqualTo("/pets/visits?petId=" + PET_ID)));
+    }
+
+    @Test
+    void getVisitsForPets_withMultiplePets() {
+        // Setup the WireMock stub for the visits service with multiple pet IDs
+        // Use urlPathEqualTo and queryParam for more flexible matching
+        wireMockServer.stubFor(get(urlPathEqualTo("/pets/visits"))
+                .withQueryParam("petId", equalTo("1,2"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"items\":[" +
+                                "{\"id\":5,\"date\":\"2018-11-15\",\"description\":\"test visit for pet 1\",\"petId\":1}," +
+                                "{\"id\":6,\"date\":\"2018-11-16\",\"description\":\"test visit for pet 2\",\"petId\":2}" +
+                                "]}")));
+
+        // Call the service client with multiple pet IDs
+        Mono<Visits> visits = visitsServiceClient.getVisitsForPets(java.util.Arrays.asList(1, 2));
+        Visits result = visits.block();
+
+        // Verify the response
+        assertNotNull(result);
+        assertEquals(2, result.items().size());
+        assertEquals(1, result.items().get(0).petId());
+        assertEquals("test visit for pet 1", result.items().get(0).description());
+        assertEquals(2, result.items().get(1).petId());
+        assertEquals("test visit for pet 2", result.items().get(1).description());
+
+        // Verify that the expected request was made to the mock server
+        // Use urlPathEqualTo and queryParam for verification to handle URL encoding
+        wireMockServer.verify(getRequestedFor(urlPathEqualTo("/pets/visits"))
+                .withQueryParam("petId", equalTo("1,2")));
+    }
+
+    private void assertVisitDescriptionEquals(Visits visits, int petId, String description) {
+        assertEquals(1, visits.items().size());
+        assertNotNull(visits.items().get(0));
+        assertEquals(petId, visits.items().get(0).petId());
+        assertEquals(description, visits.items().get(0).description());
+    }
+}

--- a/spring-petclinic-api-gateway/src/test/java/org/springframework/samples/petclinic/api/application/VisitsServiceSpringBootWireMockTest.java
+++ b/spring-petclinic-api-gateway/src/test/java/org/springframework/samples/petclinic/api/application/VisitsServiceSpringBootWireMockTest.java
@@ -1,0 +1,105 @@
+package org.springframework.samples.petclinic.api.application;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.samples.petclinic.api.dto.Visits;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import reactor.core.publisher.Mono;
+
+import java.util.Collections;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Spring Boot integration test for VisitsServiceClient using WireMock.
+ * This demonstrates how to use WireMock with Spring Boot's test framework
+ * to mock external API dependencies in integration tests.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@AutoConfigureWireMock(port = 0) // Use a random port
+@TestPropertySource(properties = {
+    "spring.cloud.discovery.enabled=false",
+    "spring.cloud.config.enabled=false",
+    "spring.cloud.loadbalancer.enabled=false"
+})
+class VisitsServiceSpringBootWireMockTest {
+
+    private static final Integer PET_ID = 1;
+
+    @Autowired
+    private VisitsServiceClient visitsServiceClient;
+
+    @Value("${wiremock.server.port}")
+    private int wireMockPort;
+
+    @BeforeEach
+    void setUp() {
+        // Reset WireMock to ensure clean state for each test
+        WireMock.reset();
+
+        // Configure the client to use the WireMock server with a direct URL
+        // This bypasses the service discovery and load balancing
+        visitsServiceClient.setHostname("http://localhost:" + wireMockPort + "/");
+
+        // Log the WireMock server URL for debugging
+        System.out.println("[DEBUG_LOG] WireMock server URL: http://localhost:" + wireMockPort + "/");
+    }
+
+    @Test
+    void getVisitsForPets_withAvailableVisitsService() {
+        // Setup the WireMock stub for the visits service
+        stubFor(get(urlEqualTo("/pets/visits?petId=" + PET_ID))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"items\":[{\"id\":5,\"date\":\"2018-11-15\",\"description\":\"test visit\",\"petId\":1}]}")));
+
+        // Call the service client
+        Mono<Visits> visits = visitsServiceClient.getVisitsForPets(Collections.singletonList(PET_ID));
+
+        // Verify the response
+        assertVisitDescriptionEquals(visits.block(), PET_ID, "test visit");
+
+        // Verify that the expected request was made to the mock server
+        verify(getRequestedFor(urlEqualTo("/pets/visits?petId=" + PET_ID)));
+    }
+
+    @Test
+    void getVisitsForPets_withErrorResponse() {
+        // Setup the WireMock stub for an error response
+        stubFor(get(urlEqualTo("/pets/visits?petId=" + PET_ID))
+                .willReturn(aResponse()
+                        .withStatus(500)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"error\":\"Internal Server Error\"}")));
+
+        // Call the service client and handle the error
+        // In a real application, you would have error handling logic
+        // For this example, we'll just catch the exception
+        try {
+            Mono<Visits> visits = visitsServiceClient.getVisitsForPets(Collections.singletonList(PET_ID));
+            visits.block(); // This should throw an exception
+        } catch (Exception e) {
+            // Expected exception
+            System.out.println("Caught expected exception: " + e.getMessage());
+        }
+
+        // Verify that the expected request was made to the mock server
+        verify(getRequestedFor(urlEqualTo("/pets/visits?petId=" + PET_ID)));
+    }
+
+    private void assertVisitDescriptionEquals(Visits visits, int petId, String description) {
+        assertEquals(1, visits.items().size());
+        assertNotNull(visits.items().get(0));
+        assertEquals(petId, visits.items().get(0).petId());
+        assertEquals(description, visits.items().get(0).description());
+    }
+}

--- a/spring-petclinic-api-gateway/src/test/resources/application-test.yml
+++ b/spring-petclinic-api-gateway/src/test/resources/application-test.yml
@@ -1,2 +1,33 @@
-spring.cloud.config.enabled: false
-eureka.client.enabled: false
+spring:
+  cloud:
+    config:
+      enabled: false
+    discovery:
+      enabled: false
+  main:
+    allow-bean-definition-overriding: true
+
+# Disable Eureka client
+eureka:
+  client:
+    enabled: false
+    register-with-eureka: false
+    fetch-registry: false
+
+# Logging configuration for tests
+logging:
+  level:
+    org.springframework.web: INFO
+    org.springframework.samples.petclinic: DEBUG
+    # WireMock logging
+    com.github.tomakehurst.wiremock: DEBUG
+
+# Circuit breaker configuration for tests
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        permittedNumberOfCallsInHalfOpenState: 3
+        waitDurationInOpenState: 5s


### PR DESCRIPTION
Use WireMock to mock external API dependencies in your Spring Boot application for integration tests.